### PR TITLE
Added column metadata parsing

### DIFF
--- a/src/Wave/DB/Column.php
+++ b/src/Wave/DB/Column.php
@@ -38,6 +38,8 @@ class Column {
 	private $extra;
     /** @var string $comment */
 	private $comment;
+    /** @var  array $metadata */
+    private $metadata = array();
 									
 	public function __construct(Table $table, $name, $nullable, $data_type, $default_value, $is_serial = false, $type_desc = '', $extra = '', $comment = ''){
 		
@@ -51,6 +53,7 @@ class Column {
 		$this->extra = $extra;
 		$this->comment = $comment;
 	
+        $this->parseMetadata($comment);
 	}
 
     /**
@@ -141,6 +144,20 @@ class Column {
 	}
 
     /**
+     * @param $key
+     * @return null
+     */
+    public function getMetadata($key = null){
+        if($key !== null){
+            if(array_key_exists($key, $this->metadata))
+                return $this->metadata[$key];
+            else
+                return null;
+        }
+        return $this->metadata;
+    }
+
+    /**
      * @return bool
      */
     public function isPrimaryKey(){
@@ -148,6 +165,14 @@ class Column {
 		
 		return $pk === null ? false : in_array($this, $pk->getColumns());
 	}
-	
+
+    private function parseMetadata($raw){
+
+        $parsed = json_decode($raw, true);
+        if(json_last_error() === JSON_ERROR_NONE && is_array($parsed)){
+            $this->metadata = $parsed;
+        }
+
+    }
 	
 }

--- a/src/Wave/DB/Generator.php
+++ b/src/Wave/DB/Generator.php
@@ -65,6 +65,7 @@ class Generator {
 		$loader = new Twig_Loader_Filesystem(__DIR__.DS.'Generator'.DS.'Templates');
 		self::$twig = new Twig_Environment($loader, array('autoescape' => false));
 		self::$twig->addFilter('addslashes', new \Twig_Filter_Function('addslashes'));
+        self::$twig->addFilter('export', new \Twig_Filter_Function(function($var){ return var_export($var, true); }));
 		self::$twig->addFilter('implode', new \Twig_Filter_Function('implode'));
 		self::$twig->addFilter('singularize', new \Twig_Filter_Function('\\Wave\\Inflector::singularize'));
         self::$twig->addFilter('formatType', new \Twig_Filter_Function('\\Wave\\DB\\Generator::formatTypeForSource'));

--- a/src/Wave/DB/Generator/Templates/base-model.phpt
+++ b/src/Wave/DB/Generator/Templates/base-model.phpt
@@ -51,7 +51,8 @@ abstract class {{ table.ClassName }} extends {{ baseModelClass }} {
 			'default'	=> {{ column.Default|formatType }},
 			'data_type'	=> {{ column.DataType }},
 			'nullable'	=> {% if column.isNullable %}true{% else %}false{% endif %},
-			'serial'    => {% if column.isSerial %}true{% else %}false{% endif %}
+			'serial'    => {% if column.isSerial %}true{% else %}false{% endif %},
+			'metadata'  => array({% for key, value in column.Metadata %}{{key|export}} =>{{value|export}}{% if not loop.last %},{% endif %} {% endfor %})
 
 		){% if not loop.last %},{% endif %}
 		

--- a/src/Wave/DB/Generator/Templates/relations/many-to-many.phpt
+++ b/src/Wave/DB/Generator/Templates/relations/many-to-many.phpt
@@ -3,7 +3,7 @@
     /**
      * {{ relation.Name }} - many-to-many
      *
-     * @param $obj {{ relation.TargetRelation.ReferencedTable.getClassName(true) }} The {{ relation.Name }} to be added
+     * @param $obj {{ relation.TargetRelation.ReferencedTable.getClassName(true) }} The {{ relation.TargetRelation.ReferencedTable.getClassName() }} to be added
      * @param bool $create_relation whether to create the relation in the database
      * @param array $join_data additional data to be saved when the relation is created, column => value array
      *
@@ -35,7 +35,7 @@
     /**
      * {{ relation.Name }}
      *
-     * @param $obj {{ relation.TargetRelation.ReferencedTable.getClassName(true) }} The {{ relation.Name }} object to be removed
+     * @param $obj {{ relation.TargetRelation.ReferencedTable.getClassName(true) }} The {{ relation.TargetRelation.ReferencedTable.getClassName() }} object to be removed
      * @param bool $remove_relation actually remove the relation from the database
      * @return bool
     **/

--- a/src/Wave/DB/Relation.php
+++ b/src/Wave/DB/Relation.php
@@ -168,7 +168,13 @@ class Relation {
 					$name .= '_'.$ref_name;	
 				break;			
 			case self::MANY_TO_MANY:
-				$name = Wave\Inflector::pluralize($this->target_relation->getReferencedTable()->getName());
+                $columns = $this->target_relation->getLocalColumns();
+                $name = $columns[0]->getMetadata('relation_name');
+                if($name === null){
+                    $name = $this->target_relation->getReferencedTable()->getName();
+                }
+
+				$name = Wave\Inflector::pluralize($name);
 				break;
 		}
 		


### PR DESCRIPTION
Allows table comments defined as JSON to provide additional meta data when generating models.

Initially supports overloading the relation name of a many-to-many relationship by defining a 'relation_name' key in the metadata JSON object.
