### PR TITLE
Php 7 compatibility

### DIFF
--- a/src/Wave/Exception.php
+++ b/src/Wave/Exception.php
@@ -86,7 +86,7 @@ class Exception extends \Exception {
         }
     }
 
-    public static function handle(\Exception $e, $send_response = true) {
+    public static function handle(\Throwable $e, $send_response = true) {
         try {
             Hook::triggerAction('exception.handle', array(&$e));
 

--- a/src/Wave/Exception.php
+++ b/src/Wave/Exception.php
@@ -86,7 +86,7 @@ class Exception extends \Exception {
         }
     }
 
-    public static function handle(\Throwable $e, $send_response = true) {
+    public static function handle($e, $send_response = true) {
         try {
             Hook::triggerAction('exception.handle', array(&$e));
 


### PR DESCRIPTION
Not declaring a type here stops PHP 7 complaining that $e is actually not an Exception while allowing usual behaviour to continue in PHP 5.X. Once 5 is history then this should probably be changed to Throwable so Errors can be caught in this manner too. 

Haven't yet found anything else that's flat out incompatible with 7 - but will look into places new features can be taken advantage of at some point. 