### PR TITLE
Base model fingerprint support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+composer.lock
+vendor/

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     ],
     "homepage": "http://github.com/wave-framework/wave",
 
-    "authors": [
-        {
+    "authors": [{
             "name": "Patrick Hindmarsh",
             "email": "patrick@hindmar.sh",
             "homepage": "https://github.com/phindmarsh"
@@ -28,7 +27,7 @@
     "bin": ["bin/wave"],
 
     "require": {
-        "php": ">=5.4.2",
+        "php": ">=7.4",
         "twig/twig": "1.*",
         "monolog/monolog": "1.*"
     },

--- a/src/Wave/DB/Column.php
+++ b/src/Wave/DB/Column.php
@@ -197,7 +197,7 @@ class Column {
      * Provide a representation of this column that can be used to calculate a 
      * fingerprint for whether it has changed or not.
      */
-    public function __serialize(){
+    public function __serialize() {
         return [
             'table' => $this->table->getName(),
             'name' => $this->getName(),

--- a/src/Wave/DB/Column.php
+++ b/src/Wave/DB/Column.php
@@ -193,4 +193,22 @@ class Column {
         $this->sequence_name = $sequence_name;
     }
 
+    /**
+     * Provide a representation of this column that can be used to calculate a 
+     * fingerprint for whether it has changed or not.
+     */
+    public function __serialize(){
+        return [
+            'table' => $this->table->getName(),
+            'name' => $this->getName(),
+            'nullable' => $this->isNullable(),
+            'data_type' => $this->getDataType(),
+            'default' => $this->getDefault(),
+            'serial' => $this->isSerial(),
+            'type_desc' => $this->getTypeDescription(),
+            'extra' => $this->getExtra(),
+            'comment' => $this->getComment()
+        ];
+    }
+
 }

--- a/src/Wave/DB/Constraint.php
+++ b/src/Wave/DB/Constraint.php
@@ -60,4 +60,16 @@ class Constraint {
         return $this->columns;
     }
 
+    /**
+     * Provide a representation of this constraint that can be used to calculate a 
+     * fingerprint for whether it has changed or not.
+     */
+    public function __serialize() {
+        return [
+            'name' => $this->getName(),
+            'type' => $this->getType(),
+            'columns' => array_map(fn($column) => $column->getName(), $this->getColumns())
+        ];
+    }
+
 }

--- a/src/Wave/DB/Generator.php
+++ b/src/Wave/DB/Generator.php
@@ -64,7 +64,7 @@ class Generator {
             $rendered_fingerprint =  $table->getSchemaFingerprint();
             $current_contents = file_get_contents($filepath);
             preg_match('/@fingerprint: ([0-9a-f]{32})/', $current_contents, $matches);
-            if($rendered_fingerprint !== $matches[1]){
+            if(!isset($matches[1]) || $rendered_fingerprint !== $matches[1]){
                 Wave\Log::write('generator', sprintf('Table [%s] has changed, updating base model file...', $table->getName()), Wave\Log::DEBUG);
                 file_put_contents($filepath, $contents);
             }

--- a/src/Wave/DB/Generator/Templates/base-model.phpt
+++ b/src/Wave/DB/Generator/Templates/base-model.phpt
@@ -12,6 +12,7 @@
  * @table:     {{ table.Name }}
  * @engine:    {{ table.Engine }}
  * @collation: {{ table.Collation }}
+ * @fingerprint: {{table.SchemaFingerprint}}
  *
  */
 

--- a/src/Wave/DB/Relation.php
+++ b/src/Wave/DB/Relation.php
@@ -202,7 +202,7 @@ class Relation {
      * Provide a representation of this relation that can be used to calculate a fingerprint
      * for whether it has changed or not. This is used by the Table getSchemaFingerprint
      */
-    public function __serialize(){ 
+    public function __serialize() { 
         $serialized = [
             'instance_name' => $this->instance_name,
             'local_columns' => array_map(fn($column) => $this->serializeColumn($column), $this->getLocalColumns()),

--- a/src/Wave/DB/Relation.php
+++ b/src/Wave/DB/Relation.php
@@ -202,7 +202,7 @@ class Relation {
      * Provide a representation of this relation that can be used to calculate a fingerprint
      * for whether it has changed or not. This is used by the Table getSchemaFingerprint
      */
-    public function __serialize(){
+    public function __serialize(){ 
         $serialized = [
             'instance_name' => $this->instance_name,
             'local_columns' => array_map(fn($column) => $this->serializeColumn($column), $this->getLocalColumns()),
@@ -221,7 +221,7 @@ class Relation {
      * database/table it comes from. Other attributes like type etc are not factored 
      * in this context
      */
-    private function serializeColumn(Column $column){
+    private function serializeColumn(Column $column) {
         return [
             $column->getTable()->getDatabase()->getName(), 
             $column->getTable()->getName(), 

--- a/src/Wave/DB/Relation.php
+++ b/src/Wave/DB/Relation.php
@@ -198,5 +198,35 @@ class Relation {
 
     }
 
+    /**
+     * Provide a representation of this relation that can be used to calculate a fingerprint
+     * for whether it has changed or not. This is used by the Table getSchemaFingerprint
+     */
+    public function __serialize(){
+        $serialized = [
+            'instance_name' => $this->instance_name,
+            'local_columns' => array_map(fn($column) => $this->serializeColumn($column), $this->getLocalColumns()),
+            'referenced_columns' => array_map(fn($column) => $this->serializeColumn($column), $this->getReferencedColumns()),
+            'is_reversed_relation' => $this->is_reverse_relation,
+            'target_relation' => $this->getTargetRelation(),
+            'type' => $this->type,
+        ];
+
+        return $serialized;
+
+    }
+
+    /**
+     * For relations, the only thing that matters is the name of the column and the 
+     * database/table it comes from. Other attributes like type etc are not factored 
+     * in this context
+     */
+    private function serializeColumn(Column $column){
+        return [
+            $column->getTable()->getDatabase()->getName(), 
+            $column->getTable()->getName(), 
+            $column->getName()
+        ];
+    }
 
 }

--- a/src/Wave/DB/Table.php
+++ b/src/Wave/DB/Table.php
@@ -146,7 +146,7 @@ class Table {
      * Makes use of overloaded __serialize() methods on the Column, Relation, and
      * Constraint components to calculate a MD5 hash.
      */
-    public function getSchemaFingerprint(){
+    public function getSchemaFingerprint() {
         $fingerprint = [
             'database' => $this->database->getName(),
             'table' => $this->table,

--- a/src/Wave/DB/Table.php
+++ b/src/Wave/DB/Table.php
@@ -138,4 +138,26 @@ class Table {
         return $prefix . Wave\Inflector::camelize($this->table);
     }
 
+    /**
+     * Returns a fingerprint of this table schema that can be used to calculate if 
+     * the table defintion has changed. This is primarily used when generating models
+     * to avoid recreating models that haven't changed.
+     * 
+     * Makes use of overloaded __serialize() methods on the Column, Relation, and
+     * Constraint components to calculate a MD5 hash.
+     */
+    public function getSchemaFingerprint(){
+        $fingerprint = [
+            'database' => $this->database->getName(),
+            'table' => $this->table,
+            'engine' => $this->engine,
+            'collation' => $this->collation,
+            'comment' => $this->comment,
+            'columns' => $this->getColumns(),
+            'relations' => $this->getRelations(),
+            'constraints' => $this->getConstraints()
+        ];
+        return md5(serialize($fingerprint));
+    }
+
 }


### PR DESCRIPTION
Adds a 'fingerprint' to the class docblock for each generated base model. This fingerprint is a MD5 hash of the serialised table schema as extracted by the DB driver.

The generator then calculates this hash and if its the same it doesn't replace the file. This means running the model generator is now idempotent. Previously files would always be touched with an updated generated timestamp, even if the schema hadn't changed.