### PR TITLE
Support generated columns

### DIFF
--- a/src/Wave/DB.php
+++ b/src/Wave/DB.php
@@ -443,6 +443,11 @@ class DB {
         $fields = $params = $placeholders = array();
         $object_data = $object->_getData();
         foreach($object->_getFields(true) as $object_field => $field_properties) {
+            //Don't take any action for generated columns.
+            if($field_properties['generated']){
+                continue;
+            }
+
             $object_value = $object_data[$object_field];
 
             $fields[] = $database->escape($object_field);

--- a/src/Wave/DB/Column.php
+++ b/src/Wave/DB/Column.php
@@ -170,6 +170,14 @@ class Column {
         return $pk === null ? false : in_array($this, $pk->getColumns());
     }
 
+    /**
+     * @return bool
+     */
+    public function isGenerated(): bool
+    {
+        return stripos($this->getExtra(), 'VIRTUAL') === 0;
+    }
+
     private function parseMetadata($raw) {
 
         $parsed = json_decode($raw, true);

--- a/src/Wave/DB/Generator/Templates/base-model.phpt
+++ b/src/Wave/DB/Generator/Templates/base-model.phpt
@@ -52,6 +52,7 @@ abstract class {{ table.ClassName }} extends {{ baseModelClass }} {
             'data_type'	=> {{ column.DataType }},
             'nullable'	=> {% if column.isNullable %}true{% else %}false{% endif %},
             'serial'    => {% if column.isSerial %}true{% else %}false{% endif %},
+            'generated'    => {% if column.isGenerated %}true{% else %}false{% endif %},
             'sequence'  => {% if column.SequenceName %}'{{ column.SequenceName }}'{% else %}null{% endif %},
             'metadata'  => array({% for key, value in column.Metadata %}{{key|export}} =>{{value|export}}{% if not loop.last %},{% endif %} {% endfor %})
 

--- a/src/Wave/DB/Generator/Templates/base-model.phpt
+++ b/src/Wave/DB/Generator/Templates/base-model.phpt
@@ -52,7 +52,7 @@ abstract class {{ table.ClassName }} extends {{ baseModelClass }} {
             'data_type'	=> {{ column.DataType }},
             'nullable'	=> {% if column.isNullable %}true{% else %}false{% endif %},
             'serial'    => {% if column.isSerial %}true{% else %}false{% endif %},
-            'generated'    => {% if column.isGenerated %}true{% else %}false{% endif %},
+            'generated' => {% if column.isGenerated %}true{% else %}false{% endif %},
             'sequence'  => {% if column.SequenceName %}'{{ column.SequenceName }}'{% else %}null{% endif %},
             'metadata'  => array({% for key, value in column.Metadata %}{{key|export}} =>{{value|export}}{% if not loop.last %},{% endif %} {% endfor %})
 


### PR DESCRIPTION
This skips any default population on inserts for generated columns, which causes errors if not explicitly set to "DEFAULT"