### PR TITLE
Add 'generated' attribute to the column serializer

### DIFF
--- a/src/Wave/DB/Column.php
+++ b/src/Wave/DB/Column.php
@@ -175,7 +175,7 @@ class Column {
      */
     public function isGenerated(): bool
     {
-        return stripos($this->getExtra(), 'VIRTUAL') === 0;
+        return stripos($this->getExtra(), 'VIRTUAL') === 0 || stripos($this->getExtra(), 'STORED') === 0;
     }
 
     private function parseMetadata($raw) {

--- a/src/Wave/DB/Column.php
+++ b/src/Wave/DB/Column.php
@@ -214,6 +214,7 @@ class Column {
             'default' => $this->getDefault(),
             'serial' => $this->isSerial(),
             'type_desc' => $this->getTypeDescription(),
+            'generated' => $this->isGenerated(),
             'extra' => $this->getExtra(),
             'comment' => $this->getComment()
         ];

--- a/src/Wave/DB/Column.php
+++ b/src/Wave/DB/Column.php
@@ -175,7 +175,7 @@ class Column {
      */
     public function isGenerated(): bool
     {
-        return stripos($this->getExtra(), 'VIRTUAL') === 0 || stripos($this->getExtra(), 'STORED') === 0;
+        return strpos($this->getExtra(), 'GENERATED') !== false;
     }
 
     private function parseMetadata($raw) {


### PR DESCRIPTION
Helps ensure that columns are regenerated appropriately if the generated status changes.