### PR TITLE
Add support for casting MySQL decimal to PHP float

### DIFF
--- a/src/Wave/DB/Driver/MySQL.php
+++ b/src/Wave/DB/Driver/MySQL.php
@@ -233,6 +233,7 @@ class MySQL extends AbstractDriver implements DriverInterface {
                 return DB\Column::TYPE_INT;
 
             case 'float':
+            case 'decimal':
                 return DB\Column::TYPE_FLOAT;
 
             case 'tinyint':


### PR DESCRIPTION
Currently if there's a column with a MySQL `decimal` type it is cast to a `string` in the model.

This PR adds support for casting `decimals` to the PHP `float` type in models.