### PR TITLE
Update model generator to format PSR-12 compliant syntax

### DIFF
--- a/src/Wave/DB/Generator/Templates/base-model.phpt
+++ b/src/Wave/DB/Generator/Templates/base-model.phpt
@@ -36,7 +36,8 @@ use Wave\DB;
 {% endif %}
  {% endfor %}
 */
-abstract class {{ table.ClassName }} extends {{ baseModelClass }} {
+abstract class {{ table.ClassName }} extends {{ baseModelClass }} 
+{
 
     //Table name
     protected static $_database = '{{ table.Database.getNamespace(false) }}';
@@ -48,13 +49,13 @@ abstract class {{ table.ClassName }} extends {{ baseModelClass }} {
 
         //{{ column.TypeDescription|raw }} {{ column.Extra }} {{ column.Comment }}
         '{{ column.Name }}' => array(
-            'default'	=> {{ column.Default|formatType }},
-            'data_type'	=> {{ column.DataType }},
-            'nullable'	=> {% if column.isNullable %}true{% else %}false{% endif %},
-            'serial'    => {% if column.isSerial %}true{% else %}false{% endif %},
+            'default' => {{ column.Default|formatType }},
+            'data_type' => {{ column.DataType }},
+            'nullable' => {% if column.isNullable %}true{% else %}false{% endif %},
+            'serial' => {% if column.isSerial %}true{% else %}false{% endif %},
             'generated' => {% if column.isGenerated %}true{% else %}false{% endif %},
-            'sequence'  => {% if column.SequenceName %}'{{ column.SequenceName }}'{% else %}null{% endif %},
-            'metadata'  => array({% for key, value in column.Metadata %}{{key|export}} =>{{value|export}}{% if not loop.last %},{% endif %} {% endfor %})
+            'sequence' => {% if column.SequenceName %}'{{ column.SequenceName }}'{% else %}null{% endif %},
+            'metadata' => array({% for key, value in column.Metadata %}{{key|export}} =>{{value|export}}{% if not loop.last %},{% endif %} {% endfor %})
 
         ){% if not loop.last %},{% endif %}
 
@@ -65,8 +66,8 @@ abstract class {{ table.ClassName }} extends {{ baseModelClass }} {
     {% for constraint in table.Constraints %}{% if constraint.Type == constant('\\Wave\\DB\\Constraint::TYPE_PRIMARY') or constraint.Type == constant('\\Wave\\DB\\Constraint::TYPE_UNIQUE')  %}
 
         '{{ constraint.Name }}' => array(
-            'type'	=> {{ constraint.Type }},
-            'fields'	=> array({% for column in constraint.Columns %}'{{ column.Name }}'{% if not loop.last %},{% endif %}{% endfor %})
+            'type' => {{ constraint.Type }},
+            'fields' => array({% for column in constraint.Columns %}'{{ column.Name }}'{% if not loop.last %}, {% endif %}{% endfor %})
 
         ){% if not loop.last %},{% endif %}
 
@@ -78,14 +79,14 @@ abstract class {{ table.ClassName }} extends {{ baseModelClass }} {
 
         //{{ relation.Description }}
         '{{ relation.Name }}' => array(
-            'relation_type'		=> {{ relation.Type }},
-            'local_columns'		=> array({% for column in relation.LocalColumns %}'{{ column.Name }}'{% if not loop.last %},{% endif %}{% endfor %}),
-            'related_class'		=> '{{ relation.ReferencedTable.getClassName(true)|addslashes }}',
-            'related_columns'	=> array({% for column in relation.ReferencedColumns %}'{{ column.Name }}'{% if not loop.last %},{% endif %}{% endfor %}),
+            'relation_type' => {{ relation.Type }},
+            'local_columns' => array({% for column in relation.LocalColumns %}'{{ column.Name }}'{% if not loop.last %},{% endif %}{% endfor %}),
+            'related_class' => '{{ relation.ReferencedTable.getClassName(true)|addslashes }}',
+            'related_columns' => array({% for column in relation.ReferencedColumns %}'{{ column.Name }}'{% if not loop.last %},{% endif %}{% endfor %}),
             {% if relation.Type ==  constant('\\Wave\\DB\\Relation::MANY_TO_MANY') %}'target_relation'	=> array(
-                'local_columns'		=> array({% for column in relation.TargetRelation.LocalColumns %}'{{ column.Name }}'{% if not loop.last %},{% endif %}{% endfor %}),
-                'related_class'		=> '{{ relation.TargetRelation.ReferencedTable.getClassName(true)|addslashes }}',
-                'related_columns'	=> array({% for column in relation.TargetRelation.ReferencedColumns %}'{{ column.Name }}'{% if not loop.last %},{% endif %}{% endfor %}),
+                'local_columns' => array({% for column in relation.TargetRelation.LocalColumns %}'{{ column.Name }}'{% if not loop.last %},{% endif %}{% endfor %}),
+                'related_class' => '{{ relation.TargetRelation.ReferencedTable.getClassName(true)|addslashes }}',
+                'related_columns' => array({% for column in relation.TargetRelation.ReferencedColumns %}'{{ column.Name }}'{% if not loop.last %},{% endif %}{% endfor %}),
             )
             {% endif %}
 
@@ -96,11 +97,13 @@ abstract class {{ table.ClassName }} extends {{ baseModelClass }} {
     {% for column in table.Columns %}
 
     //{{ column.TypeDescription|raw }} {{ column.Extra }} {{ column.Comment }}
-    public function get{{ column.Name }}(){
+    public function get{{ column.Name }}()
+    {
         return $this->_data['{{ column.Name }}'];
     }
 
-    public function set{{ column.Name }}($value){
+    public function set{{ column.Name }}($value)
+    {
         $this->_data['{{ column.Name }}'] = $value;
         $this->_dirty['{{ column.Name }}'] = true;
         return $this;
@@ -117,7 +120,6 @@ abstract class {{ table.ClassName }} extends {{ baseModelClass }} {
     {% endif %}
 
     {% endfor %}
-
 
 
 }

--- a/src/Wave/DB/Generator/Templates/base-model.phpt
+++ b/src/Wave/DB/Generator/Templates/base-model.phpt
@@ -83,7 +83,7 @@ abstract class {{ table.ClassName }} extends {{ baseModelClass }}
             'local_columns' => array({% for column in relation.LocalColumns %}'{{ column.Name }}'{% if not loop.last %},{% endif %}{% endfor %}),
             'related_class' => '{{ relation.ReferencedTable.getClassName(true)|addslashes }}',
             'related_columns' => array({% for column in relation.ReferencedColumns %}'{{ column.Name }}'{% if not loop.last %},{% endif %}{% endfor %}),
-            {% if relation.Type ==  constant('\\Wave\\DB\\Relation::MANY_TO_MANY') %}'target_relation'	=> array(
+            {% if relation.Type ==  constant('\\Wave\\DB\\Relation::MANY_TO_MANY') %}'target_relation' => array(
                 'local_columns' => array({% for column in relation.TargetRelation.LocalColumns %}'{{ column.Name }}'{% if not loop.last %},{% endif %}{% endfor %}),
                 'related_class' => '{{ relation.TargetRelation.ReferencedTable.getClassName(true)|addslashes }}',
                 'related_columns' => array({% for column in relation.TargetRelation.ReferencedColumns %}'{{ column.Name }}'{% if not loop.last %},{% endif %}{% endfor %}),

--- a/src/Wave/DB/Generator/Templates/relations/many-to-many.phpt
+++ b/src/Wave/DB/Generator/Templates/relations/many-to-many.phpt
@@ -9,7 +9,8 @@
      *
      * @return $this
     **/
-    public function add{{ relation.Name|singularize }}({{ relation.TargetRelation.ReferencedTable.getClassName(true) }} &$object, $create_relation = true, array $join_data = array()){
+    public function add{{ relation.Name|singularize }}({{ relation.TargetRelation.ReferencedTable.getClassName(true) }} &$object, $create_relation = true, array $join_data = array())
+    {
         $this->_addRelationObject('{{ relation.Name }}', $object, $create_relation, $join_data);
         return $this;
     }
@@ -21,7 +22,8 @@
      * @param bool $remove_relation actually remove the relation from the database
      * @return $this
     **/
-    public function remove{{ relation.Name|singularize }}({{ relation.TargetRelation.ReferencedTable.getClassName(true) }} &$object, $remove_relation = true){
+    public function remove{{ relation.Name|singularize }}({{ relation.TargetRelation.ReferencedTable.getClassName(true) }} &$object, $remove_relation = true)
+    {
         $this->_removeRelationObject('{{ relation.Name }}', $object, $remove_relation);
         return $this;
     }
@@ -32,7 +34,8 @@
      * @param callable $transform_callback
      * @return {{ relation.TargetRelation.ReferencedTable.getClassName(true) }}[]
     **/
-    public function get{{ relation.Name }}(){
+    public function get{{ relation.Name }}()
+    {
         $transform_callback = func_num_args() >= 1 ? func_get_arg(0) : null;
         return $this->_getRelationObjects('{{ relation.Name }}', $transform_callback);
     }

--- a/src/Wave/DB/Generator/Templates/relations/many-to-one.phpt
+++ b/src/Wave/DB/Generator/Templates/relations/many-to-one.phpt
@@ -8,7 +8,8 @@
      *
      * @return $this
     **/
-    public function set{{ relation.Name }}({{ relation.ReferencedTable.getClassName(true) }} &$object = null, $create_relation = true){
+    public function set{{ relation.Name }}({{ relation.ReferencedTable.getClassName(true) }} &$object = null, $create_relation = true)
+    {
         $this->_setRelationObject('{{ relation.Name }}', $object, $create_relation);
         return $this;
     }
@@ -19,7 +20,8 @@
      * @param callable $transform_callback
      * @return {{ relation.ReferencedTable.getClassName(true) }}
     **/
-    public function get{{ relation.Name }}(){
+    public function get{{ relation.Name }}()
+    {
         $transform_callback = func_num_args() >= 1 ? func_get_arg(0) : null;
         return $this->_getRelationObjects('{{ relation.Name }}', $transform_callback);
     }

--- a/src/Wave/DB/Generator/Templates/relations/one-to-many.phpt
+++ b/src/Wave/DB/Generator/Templates/relations/one-to-many.phpt
@@ -8,7 +8,8 @@
      *
      * @return $this
     **/
-    public function add{{ relation.Name|singularize }}({{ relation.ReferencedTable.getClassName(true) }} &$object, $create_relation = true){
+    public function add{{ relation.Name|singularize }}({{ relation.ReferencedTable.getClassName(true) }} &$object, $create_relation = true)
+    {
         $this->_addRelationObject('{{ relation.Name }}', $object, $create_relation);
         return $this;
     }
@@ -20,7 +21,8 @@
      * @param bool $delete_object whether to delete the object in the database
      * @return $this
     **/
-    public function remove{{ relation.Name|singularize }}({{ relation.ReferencedTable.getClassName(true) }} $object, $delete_object = true){
+    public function remove{{ relation.Name|singularize }}({{ relation.ReferencedTable.getClassName(true) }} $object, $delete_object = true)
+    {
         $this->_removeRelationObject('{{ relation.Name }}', $object, $delete_object);
         return $this;
     }
@@ -31,7 +33,8 @@
      * @param callable $transform_callback
      * @return {{ relation.ReferencedTable.getClassName(true) }}[]
     **/
-    public function get{{ relation.Name }}(){
+    public function get{{ relation.Name }}()
+    {
         $transform_callback = func_num_args() >= 1 ? func_get_arg(0) : null;
         return $this->_getRelationObjects('{{ relation.Name }}', $transform_callback);
     }

--- a/src/Wave/DB/Generator/Templates/relations/one-to-one.phpt
+++ b/src/Wave/DB/Generator/Templates/relations/one-to-one.phpt
@@ -8,7 +8,8 @@
      *
      * @return $this
     **/
-    public function set{{ relation.Name }}(&$obj = null, $create_relation = true){
+    public function set{{ relation.Name }}(&$obj = null, $create_relation = true)
+    {
         $this->_setRelationObject('{{ relation.Name }}', $obj, $create_relation);
         return $this;
     }
@@ -19,7 +20,8 @@
      * @param callable $transform_callback
      * @return {{ relation.ReferencedTable.getClassName(true) }}
     **/
-    public function get{{ relation.Name }}(){
+    public function get{{ relation.Name }}()
+    {
         $transform_callback = func_num_args() >= 1 ? func_get_arg(0) : null;
         return $this->_getRelationObjects('{{ relation.Name }}', $transform_callback);
     }

--- a/src/Wave/DB/Generator/Templates/stub-model.phpt
+++ b/src/Wave/DB/Generator/Templates/stub-model.phpt
@@ -16,6 +16,7 @@
 
 namespace {{ table.Database.Namespace }};
 
-class {{ table.ClassName }} extends Base\{{ table.ClassName }} {
+class {{ table.ClassName }} extends Base\{{ table.ClassName }} 
+{
 
 }


### PR DESCRIPTION
This PR makes some minor formatting changes to the generated base and stub models to align the output to PSR-12.

It means if regenerating base models in a project that is PSR-12-compliant they maintain that compliance.