### PR TITLE
ORM Fixes

### DIFF
--- a/src/Wave/DB/Model.php
+++ b/src/Wave/DB/Model.php
@@ -223,7 +223,7 @@ class Model implements \JsonSerializable {
 
     public function _equals(Model $object) {
         return (get_class($this) === get_class($object)) &&
-        array_diff_assoc($this->_getIdentifyingData(), $object->_getIdentifyingData());
+        count(array_diff_assoc($this->_getIdentifyingData(), $object->_getIdentifyingData())) === 0;
     }
 
     /**
@@ -241,6 +241,27 @@ class Model implements \JsonSerializable {
             $this->_joined_objects[$alias] = array();
 
         $this->_joined_objects[$alias][] = $object;
+    }
+
+    /**
+     * Determine whether a joined object has already been joined under a specific alias
+     *
+     * @param Model $object
+     * @param $alias
+     * @return bool
+     */
+    public function hasJoinedObject(Model &$object, $alias): bool
+    {
+        if(!isset($this->_joined_objects[$alias]))
+            return false;
+
+        foreach ($this->_joined_objects[$alias] as $joined_object) {
+               if ($object->_equals($joined_object)) {
+                   return true;
+               }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Wave/DB/Model.php
+++ b/src/Wave/DB/Model.php
@@ -234,7 +234,9 @@ class Model implements \JsonSerializable {
      * @param $resolved_class
      */
     public function addJoinedObject(Model &$object, $alias, $resolved_class) {
-        $this->_joined_aliases[$resolved_class][] = $alias;
+        if (!isset($this->_joined_aliases[$resolved_class]) || !in_array($alias, $this->_joined_aliases[$resolved_class]))
+            $this->_joined_aliases[$resolved_class][] = $alias;
+
         if(!isset($this->_joined_objects[$alias]))
             $this->_joined_objects[$alias] = array();
 

--- a/src/Wave/DB/Query.php
+++ b/src/Wave/DB/Query.php
@@ -792,8 +792,17 @@ class Query {
                                 $object_instances[$join['target_alias']]->{'add' . $this->with[$join['table_alias']]['relation_name']}($object_instances[$join['table_alias']], false);
                                 break;
                         }
-                    } else
+                    } else {
+                        // Don't join equivalent objects to the same target multiple times
+                        $already_joined = $object_instances[$join['target_alias']]->hasJoinedObject($object_instances[$join['table_alias']], $join['table_alias']);
+                        if ($already_joined) {
+                            Wave\Log::write('database', 'Duplicate child (join) results detected. Should this query have a group by?', Wave\Log::DEBUG);
+                            continue;
+                        }
+
                         $object_instances[$join['target_alias']]->addJoinedObject($object_instances[$join['table_alias']], $join['table_alias'], $this->unaliasClass($join['table_alias']));
+                    }
+
 
                 }
 


### PR DESCRIPTION
– Added ability to avoid hydrating objects from joins onto the main model being queried
– Fixed an issue where joined aliases are duplicated, resulting in extra objects being returned in calls to getJoinedObjectsForClass